### PR TITLE
remove omitemty for GetVariableResult.AttributeValue

### DIFF
--- a/ocpp2.0.1/provisioning/get_variables.go
+++ b/ocpp2.0.1/provisioning/get_variables.go
@@ -41,7 +41,7 @@ type GetVariableData struct {
 type GetVariableResult struct {
 	AttributeStatus GetVariableStatus `json:"attributeStatus" validate:"required,getVariableStatus"`
 	AttributeType   types.Attribute   `json:"attributeType,omitempty" validate:"omitempty,attribute"`
-	AttributeValue  string            `json:"attributeValue,omitempty" validate:"omitempty,max=1000"`
+	AttributeValue  string            `json:"attributeValue" validate:"max=1000"`
 	Component       types.Component   `json:"component" validate:"required"`
 	Variable        types.Variable    `json:"variable" validate:"required"`
 }


### PR DESCRIPTION
- In the Test preparations of the OCTT test cases **TC_J_03** and **TC_J_10_CS** , the attributeValue of  _SampledDataTxEndedMeasurands_ and _AlignedDataTxEndedMeasurands_ are respectively set to empty string by the CSMS , using the setVariable() message.

* Ref:
https://ecog-324595e6999a17ae.octt.openchargealliance.org/assets/secure/content/html_pdf/ocpp201/cs.html#TC_J_10_CS
https://ecog-324595e6999a17ae.octt.openchargealliance.org/assets/secure/content/html_pdf/ocpp201/cs.html#TC_J_03_CS

- And according to the specs under B06.FR.13 in https://gitlab.com/ecog/ux-ctrl/ocpp-ng/-/raw/main/doc/OCPP-2.0.1_part2_specification_edition2.pdf#page=56,
When the attributeValue is empty , Charging Station SHALL return an empty string as attributeValue.
However, in the current library fork,  we omit attributeValue whose value is empty as shown in the attached screenshot.
![GetVariableResult](https://github.com/user-attachments/assets/d34f4b05-2399-4b2d-96a1-3f4358b8d6e7)
